### PR TITLE
Add Deep Blue Alpha to Ethereum Analytics and Block Explorers

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@
 - **[Nansen](https://www.nansen.ai/)** - Provides insights and analytics on Ethereum transactions and DeFi activity.
 - **[Zapper](https://zapper.fi/)** - A dashboard for tracking DeFi assets and yield farming positions.
 - **[DeBank](https://debank.com/)** - An analytics tool for managing DeFi portfolios.
+- **[Deep Blue Alpha](https://deepbluealpha.io)** - A free real-time Ethereum whale-tracking dashboard monitoring 15,331+ labeled wallets with sentiment scoring and a 30-day conviction scoreboard.
 
 ## Layer 2 Solutions
 


### PR DESCRIPTION
Adds Deep Blue Alpha (https://deepbluealpha.io) to the Ethereum Analytics and Block Explorers section. It is a free, real-time Ethereum whale-tracking dashboard monitoring 15,331+ labeled wallets with sentiment scoring and a 30-day conviction scoreboard. Fits alongside Dune, Nansen, Zapper, and DeBank as an Ethereum-focused analytics tool. Link is active, no signup required, fully free. Formatted to match the existing section style per CONTRIBUTING.md.