### PR TITLE
Add Web3 Discover to dApps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@
 - **[MakerDAO](https://makerdao.com/)** - A decentralized protocol for generating the stablecoin DAI using Ethereum as collateral.
 - **[Compound](https://compound.finance/)** - A protocol for lending and borrowing Ethereum-based assets.
 - **[OpenSea](https://opensea.io/)** - The largest NFT marketplace on Ethereum.
+- **[Web3 Discover](https://web3-discover.vercel.app)** - A hand-vetted directory of currently-claimable Ethereum and EVM airdrops; deadline-sorted, every entry "last verified" stamped. No paid listings.
 
 ## Ethereum Analytics and Block Explorers
 


### PR DESCRIPTION
Adds [web3-discover](https://web3-discover.vercel.app) — a hand-vetted directory of 42 currently-claimable web3 airdrops.

Why this fits this list:
- Curated (not auto-aggregated); every entry has a chain, cost-floor, risk flag, and a "last verified" date stamp
- No paid listings, no wallet-connect, no JS that touches user funds
- Deadline-sorted; filters by chain / risk / effort / free-to-enter
- Ships a paste-your-wallet eligibility checker, an MCP server (`/api/mcp`), and a public CC0 data mirror at https://github.com/SolvoHQ/web3-discover-data

One-line addition, no schema changes. Happy to drop the entry in a different section if you prefer — just let me know.