### PR TITLE
Add Deep Blue Alpha to Analytics section

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@
 - **[Nansen](https://www.nansen.ai/)** - Provides insights and analytics on Ethereum transactions and DeFi activity.
 - **[Zapper](https://zapper.fi/)** - A dashboard for tracking DeFi assets and yield farming positions.
 - **[DeBank](https://debank.com/)** - An analytics tool for managing DeFi portfolios.
+- - **[Deep Blue Alpha](https://deepbluealpha.io/)** – Real-time Ethereum whale intelligence tracking 20,000+ wallets with conviction scoring and hourly flow reports.
 
 ## Layer 2 Solutions
 


### PR DESCRIPTION
Adds Deep Blue Alpha (deepbluealpha.io) to the Ethereum Analytics and Block Explorers section. Real-time whale intelligence platform tracking 20,000+ Ethereum wallets with conviction scoring and hourly flow reports.

## Thank you for your contribution!

Please make sure your pull request follows our guidelines:

### Checklist

- [x] My submission is useful and relevant to this list.