### PR TITLE
Add CryptoCalk to Ethereum Tools and Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@
 - **[Infura](https://infura.io/)** - A service providing scalable Ethereum and IPFS APIs.
 - **[Alchemy](https://www.alchemy.com/)** - A platform offering developer tools and infrastructure for building Ethereum dApps.
 - **[The Graph](https://thegraph.com/)** - An indexing protocol for querying blockchain data.
+- **[CryptoCalk](https://cryptocalk.com)** - Free Ethereum-focused calculators: ETH staking rewards, gas fee estimator, MEV calculator, liquid staking (LST), restaking ROI, validator earnings, EIP-1559 fee breakdown, liquidation price, ETH DCA simulator. Client-side, no signup, 6 languages.
 
 ## Ethereum Wallets
 


### PR DESCRIPTION
[CryptoCalk](https://cryptocalk.com) is a free Ethereum-focused calculator suite, added to the **Ethereum Tools and Libraries** section.

**Ethereum-specific calculators included:**
- ETH staking rewards (solo and pooled)
- Gas fee estimator (EIP-1559 breakdown: base + priority)
- MEV calculator
- Liquid staking (LST) yields — Lido, Rocket Pool, Frax
- Restaking ROI — EigenLayer-style
- Validator earnings projections
- Liquidation price for leveraged ETH positions
- ETH DCA simulator (historical backtest)
- Network energy use

All tools run client-side — no signup, no data collection. Available in 6 languages.