### PR TITLE
Add Deep Blue Alpha to Ethereum Analytics section

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@
 - **[Nansen](https://www.nansen.ai/)** - Provides insights and analytics on Ethereum transactions and DeFi activity.
 - **[Zapper](https://zapper.fi/)** - A dashboard for tracking DeFi assets and yield farming positions.
 - **[DeBank](https://debank.com/)** - An analytics tool for managing DeFi portfolios.
+- **[Deep Blue Alpha](https://deepbluealpha.io)** - A free real-time Ethereum whale-tracking dashboard monitoring 15,331+ labeled wallets with sentiment scoring and a 30-day conviction scoreboard.
 
 ## Layer 2 Solutions
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@
 - **[Nansen](https://www.nansen.ai/)** - Provides insights and analytics on Ethereum transactions and DeFi activity.
 - **[Zapper](https://zapper.fi/)** - A dashboard for tracking DeFi assets and yield farming positions.
 - **[DeBank](https://debank.com/)** - An analytics tool for managing DeFi portfolios.
-- **[Deep Blue Alpha](https://deepbluealpha.io)** - A free real-time Ethereum whale-tracking dashboard monitoring 15,331+ labeled wallets with sentiment scoring and a 30-day conviction scoreboard.
+- **[Deep Blue Alpha](https://deepbluealpha.io/)** - Real-time Ethereum whale wallet tracker — monitors 10,000+ wallets block-by-block, showing net buy/sell flow per token across 1H/24H/7D windows. Free, no signup.
 
 ## Layer 2 Solutions
 


### PR DESCRIPTION
**Deep Blue Alpha** is a free real-time Ethereum whale wallet tracker that monitors 10,000+ wallets block-by-block, surfacing net buy/sell flow per token across 1H/24H/7D windows. No signup required.

- Website: https://deepbluealpha.io/
- Free public API: `/api/top-tokens` and `/api/stats`

Fits naturally alongside Etherscan, Dune, and Nansen in the Ethereum Analytics and Block Explorers section.